### PR TITLE
chore: replace prettier with biome

### DIFF
--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       lua: ${{ steps.changes.outputs.lua }}
-      markdown: ${{ steps.changes.outputs.markdown }}
+      biome: ${{ steps.changes.outputs.biome }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -26,8 +26,14 @@ jobs:
               - '.luarc.json'
               - '*.toml'
               - 'vim.yaml'
-            markdown:
-              - '*.md'
+            biome:
+              - '.luarc.json'
+              - 'biome.json'
+              - '.editorconfig'
+              - '.pre-commit-config.yaml'
+              - 'flake.nix'
+              - 'flake.lock'
+              - '.github/workflows/quality.yaml'
 
   lua-format:
     name: Lua Format Check
@@ -63,12 +69,12 @@ jobs:
           directories: lua
           configpath: .luarc.json
 
-  markdown-format:
-    name: Markdown Format Check
+  biome-format:
+    name: Biome Format Check
     runs-on: ubuntu-latest
     needs: changes
-    if: ${{ needs.changes.outputs.markdown == 'true' }}
+    if: ${{ needs.changes.outputs.biome == 'true' }}
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v31
-      - run: nix develop --command prettier --check .
+      - run: nix develop --command biome format biome.json .luarc.json

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,9 +9,11 @@ repos:
         files: \.lua$
         pass_filenames: true
 
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v4.0.0-alpha.8
+  - repo: local
     hooks:
-      - id: prettier
-        name: prettier
-        files: \.(md|toml|yaml|yml|sh)$
+      - id: biome
+        name: biome
+        entry: nix develop --command biome format --write --no-errors-on-unmatched
+        language: system
+        files: \.(cjs|css|gql|graphql|html|js|json|jsonc|jsx|mjs|cts|mts|ts|tsx)$
+        pass_filenames: true

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,0 @@
-node_modules/

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,9 +1,0 @@
-{
-  "proseWrap": "always",
-  "printWidth": 80,
-  "tabWidth": 2,
-  "useTabs": false,
-  "trailingComma": "none",
-  "semi": false,
-  "singleQuote": true
-}

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.11/schema.json",
+  "vcs": { "enabled": true, "clientKind": "git", "useIgnoreFile": true },
+  "files": { "ignoreUnknown": false },
+  "formatter": {
+    "enabled": true,
+    "formatWithErrors": false,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineEnding": "lf",
+    "lineWidth": 80,
+    "attributePosition": "auto",
+    "bracketSameLine": false,
+    "bracketSpacing": true,
+    "expand": "auto",
+    "useEditorconfig": true,
+    "includes": ["**", "!**/node_modules/"]
+  },
+  "javascript": {
+    "formatter": {
+      "jsxQuoteStyle": "double",
+      "quoteProperties": "asNeeded",
+      "trailingCommas": "none",
+      "semicolons": "asNeeded",
+      "arrowParentheses": "always",
+      "bracketSameLine": false,
+      "quoteStyle": "single",
+      "attributePosition": "auto",
+      "bracketSpacing": true
+    }
+  }
+}

--- a/flake.nix
+++ b/flake.nix
@@ -25,7 +25,7 @@
                 nlua
               ]
             ))
-            pkgs.prettier
+            pkgs.biome
             pkgs.stylua
             pkgs.selene
           ];


### PR DESCRIPTION
Replace Prettier with Biome in the Nix dev shell, pre-commit hook, and quality workflow, and add a repo Biome config migrated from the previous Prettier settings. This removes the obsolete Prettier config files and was verified with biome format, stylua --check, selene, busted, and pre-commit run --all-files.